### PR TITLE
Disable when output stream is not TTY

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ var progressOptions = {
 };
 
 function SimpleProgressPlugin(options) {
+  if (!process.stderr.isTTY) {
+    return function () {};
+  }
+
   if (options) {
     messageTemplate = options.messageTemplate || messageTemplate;
     progressOptions = objectAssign(progressOptions, options.progressOptions);


### PR DESCRIPTION
I've fixed a bug when a build using webpack-simple-progress-plugin would crash if the output stream is non-TTY (at least in our server build setups). This has led me to implement a simple check identical to the one progress-bar-webpack-plugin uses [here](https://github.com/clessg/progress-bar-webpack-plugin/blob/master/index.js#L11).

I've opted to not make the output stream configurable by an option like progress-bar-webpack-plugin does. The primary strength of this plugin is simplicity, so this seems a bit out of scope. At least for the time being.